### PR TITLE
feat: allow using decorators to register substeps/generators

### DIFF
--- a/AgentTorch/registry.py
+++ b/AgentTorch/registry.py
@@ -37,6 +37,7 @@ class Registry(nn.Module):
             cls.helpers[key][name] = fn
             return fn
         return decorator
+    register_substep = register_helper
 
 if __name__ == '__main__':
     reg = Registry()

--- a/AgentTorch/registry.py
+++ b/AgentTorch/registry.py
@@ -4,22 +4,22 @@ import torch.nn as nn
 import json
 
 class Registry(nn.Module):
-    
+    helpers = {
+      "transition": {},
+      "observation": {},
+      "policy": {},
+      "initialization": {},
+      "network": {},
+    }
+
     def __init__(self):
         super().__init__()
-        self.initialization_helpers = {}
-        self.observation_helpers = {}
-        self.policy_helpers = {}
-        self.transition_helpers = {}
-        self.network_helpers = {}
-        
-        self.helpers = {}
-        self.helpers["transition"] = self.transition_helpers
-        self.helpers["observation"] = self.observation_helpers
-        self.helpers["policy"] = self.policy_helpers
-        self.helpers["initialization"] = self.initialization_helpers
-        self.helpers["network"] = self.network_helpers
-        
+        self.initialization_helpers = self.helpers["transition"]
+        self.observation_helpers = self.helpers["observation"]
+        self.policy_helpers = self.helpers["policy"]
+        self.transition_helpers = self.helpers["initialization"]
+        self.network_helpers = self.helpers["network"]
+
     def register(self, obj_source, name, key):
         '''Inserts a new function into the registry'''
         self.helpers[key][name] = obj_source
@@ -30,6 +30,13 @@ class Registry(nn.Module):
     
     def forward(self):
         print("Invoke registry.register(class_obj, key)")
+
+    @classmethod
+    def register_helper(cls, name, key):
+        def decorator(fn):
+            cls.helpers[key][name] = fn
+            return fn
+        return decorator
 
 if __name__ == '__main__':
     reg = Registry()

--- a/AgentTorch/test/decorators.py
+++ b/AgentTorch/test/decorators.py
@@ -1,0 +1,26 @@
+# test/decorators.py
+# tests if the decorators work
+
+# not an actual test, todo: write this using python's unittest
+# along with the other tests
+
+import sys
+sys.path.insert(0, '../')
+from AgentTorch.registry import Registry
+from AgentTorch.substep import SubstepAction
+
+@Registry.register_helper("generate_something", "initialization")
+def generate_something():
+  print("something!")
+
+@Registry.register_helper("AcceptTest", "policy")
+class AcceptTest(SubstepAction):
+    def __init__(self, config, input_variables, output_variables, arguments):
+        super().__init__(config, input_variables, output_variables, arguments)
+        pass
+
+    def forward(self, state, observation):    
+        pass
+
+registry = Registry()
+print(registry.helpers)

--- a/AgentTorch/test/decorators.py
+++ b/AgentTorch/test/decorators.py
@@ -11,10 +11,10 @@ from AgentTorch.substep import SubstepAction
 
 @Registry.register_helper("generate_something", "initialization")
 def generate_something():
-  print("something!")
+  pass
 
-@Registry.register_helper("AcceptTest", "policy")
-class AcceptTest(SubstepAction):
+@Registry.register_substep("do_something", "policy")
+class DoSomething(SubstepAction):
     def __init__(self, config, input_variables, output_variables, arguments):
         super().__init__(config, input_variables, output_variables, arguments)
         pass


### PR DESCRIPTION
Resolves #11.

If this pr is merged, substeps and helper functions like generators could be registered like so:

```python
from AgentTorch.registry import Registry
from AgentTorch.substep import SubstepAction

@Registry.register_helper("generate_something", "initialization")
def generate_something():
	pass

@Registry.register_substep("do_something", "policy")
class DoSomething(SubstepAction):
	def __init__(self, config, input_variables, output_variables, arguments):
		super().__init__(config, input_variables, output_variables, arguments)
		pass

	def forward(self, state, observation):
		pass

registry = Registry()
print(registry.helpers)
```
