### PR TITLE
fix: assign helpers correctly

### DIFF
--- a/AgentTorch/registry.py
+++ b/AgentTorch/registry.py
@@ -14,10 +14,10 @@ class Registry(nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.initialization_helpers = self.helpers["transition"]
+        self.initialization_helpers = self.helpers["initialization"]
         self.observation_helpers = self.helpers["observation"]
         self.policy_helpers = self.helpers["policy"]
-        self.transition_helpers = self.helpers["initialization"]
+        self.transition_helpers = self.helpers["transition"]
         self.network_helpers = self.helpers["network"]
 
     def register(self, obj_source, name, key):

--- a/AgentTorch/test/decorators.py
+++ b/AgentTorch/test/decorators.py
@@ -13,6 +13,9 @@ from AgentTorch.substep import SubstepAction
 def generate_something():
   pass
 
+def another_helper():
+  pass
+
 @Registry.register_substep("do_something", "policy")
 class DoSomething(SubstepAction):
     def __init__(self, config, input_variables, output_variables, arguments):
@@ -23,4 +26,5 @@ class DoSomething(SubstepAction):
         pass
 
 registry = Registry()
+registry.register(another_helper, "another_helper", "initialization")
 print(registry.helpers)


### PR DESCRIPTION
This PR fixes a copy-paste error I made in #13.

It also adds a test to make sure the original `registry.register()` function works.