### PR TITLE
fix: do not re-register resolvers for `OmegaConfig`

### DIFF
--- a/agent_torch/core/helpers/general.py
+++ b/agent_torch/core/helpers/general.py
@@ -91,20 +91,32 @@ def register_resolver(name, resolver):
     OmegaConf.register_new_resolver(name, resolver)
 
 
-def read_config(config_file,register_resolvers = True):
+def read_config(config_file, register_resolvers=True):
     if register_resolvers:
-        register_resolver("sum", lambda x, y: x + y)
-        register_resolver("multiply", lambda x, y: x * y)
-        register_resolver("divide", lambda x, y: x // y)
+        resolvers = [
+            ("sum", lambda x, y: x + y),
+            ("multiply", lambda x, y: x * y),
+            ("divide", lambda x, y: x // y),
+        ]
+
+        for name, func in resolvers:
+            try:
+                OmegaConf.register_resolver(name, func)
+            except AssertionError as e:
+                if "is already registered" in str(e):
+                    continue
+                else:
+                    raise e
 
     if config_file[-5:] != ".yaml":
         raise ValueError("Config file type should be yaml")
+
     try:
         config = OmegaConf.load(config_file)
         config = OmegaConf.to_object(config)
     except Exception as e:
         raise ValueError(
-            f"Could not load config file. Please check path ad file type. Error message is {str(e)}"
+            f"Could not load config file. Please check path and file type. Error message is {str(e)}"
         )
 
     return config


### PR DESCRIPTION
This PR addresses an issue where the `read_config` function was raising an error when attempting to register resolvers that were already registered.

Changes made:
- Added try-except block to catch ValueError when registering resolvers
- Implemented logic to ignore "already registered" errors and continue execution
- Maintained error raising for other types of ValueErrors

This change allows the function to continue executing even when encountering already registered resolvers, improving its robustness and usability.