### PR TITLE
Bug Fix in Predator-Prey Model Substeps

### DIFF
--- a/agent_torch/models/predator_prey/substeps/eat.py
+++ b/agent_torch/models/predator_prey/substeps/eat.py
@@ -63,7 +63,7 @@ class EatGrass(SubstepTransition):
         regrowth_time = get_var(state, input_variables["regrowth_time"])
 
         # if no grass can be eaten, skip modifying the state.
-        if len(action["prey"]["eatable_grass_positions"]) < 1:
+        if (action["prey"] is None) or (len(action["prey"]["eatable_grass_positions"]) < 1):
             return {}
 
         eatable_grass_positions = torch.stack(

--- a/agent_torch/models/predator_prey/substeps/hunt.py
+++ b/agent_torch/models/predator_prey/substeps/hunt.py
@@ -57,7 +57,7 @@ class HuntPrey(SubstepTransition):
         nutrition = get_var(state, input_variables["nutritional_value"])
 
         # if there are no targets, skip the state modifications.
-        if len(action["predator"]["target_positions"]) < 1:
+        if (action["predator"] is None) or (len(action["predator"]["target_positions"]) < 1):
             return {}
 
         target_positions = torch.stack(action["predator"]["target_positions"], dim=0)


### PR DESCRIPTION
Since `controller.py` returns `None` in case of exceptions, the action profiles of agents can be of `NoneType` and it causes an error during simulation. Having an additional condition to check for the `NoneType` object in `eat.py` and `hunt.py` hopefully resolves the issue.